### PR TITLE
bugfix/react-icons: moved react-icons dependecy from devDependencies …

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,8 @@
     "react-bootstrap": "^1.4.0",
     "react-dom": "^17.0.1",
     "react-router-dom": "^5.2.0",
-    "react-scripts": "3.4.4"
+    "react-scripts": "3.4.4",
+    "react-icons": "^3.11.0"
   },
   "scripts": {
     "start": "react-scripts start",
@@ -37,7 +38,6 @@
   "devDependencies": {
     "chromedriver": "^86.0.0",
     "geckodriver": "^1.20.0",
-    "nightwatch": "^1.5.0",
-    "react-icons": "^3.11.0"
+    "nightwatch": "^1.5.0"
   }
 }


### PR DESCRIPTION
…to main dependencies.

I just realized I put this by mistake into development deps only, it should be in our main deps to work with production build.