### PR TITLE
feature/debug: added configuration files for debugging the frontend a…

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,0 +1,1 @@
+BROWSER=none

--- a/frontend/.vscode/launch.json
+++ b/frontend/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+      {
+        "name": "Debug in Chrome",
+        "type": "chrome",
+        "request": "launch",
+        "preLaunchTask": "debug-start",
+        "postDebugTask": "debug-stop",
+        "url": "http://localhost:3000",
+        "skipFiles": [
+          "<node_internals>/**",
+          "node_modules/**",
+          "bootstrap"
+        ]
+      }
+    ]
+  }

--- a/frontend/.vscode/tasks.json
+++ b/frontend/.vscode/tasks.json
@@ -1,0 +1,35 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+      {
+        "label": "debug-start",
+        "command": "npm.cmd",
+        "args": ["start"],
+        "isBackground": true,
+        "problemMatcher": {
+          "fileLocation": "relative",
+          "pattern": {
+            "regexp": "^$"
+          },
+          "background": {
+            "activeOnStart": true,
+            "beginsPattern": "^$",
+            "endsPattern": "(^You can now view (.*) in the browser.$)|(^Compiled with warnings.$)"
+          }
+        }
+      },
+      {
+        "label": "debug-stop",
+        "command": "echo ${input:terminate}",
+        "type": "shell"
+      }
+    ],
+    "inputs": [
+      {
+        "id": "terminate",
+        "type": "command",
+        "command": "workbench.action.tasks.terminate",
+        "args": "debug-start"
+      }
+    ]
+  }


### PR DESCRIPTION
…pp in VSCode

Debug mode can now be started simply by pressing F5 under the frontend app folder (no need for npm start etc). This assumes your workspace is set up so the frontend folder is added to the workspace, and not just the Git repo root folder.