### PR TITLE
bugfix/Expense_page_style: style fixed

### DIFF
--- a/frontend/src/components/ExpenseAdd.js
+++ b/frontend/src/components/ExpenseAdd.js
@@ -43,22 +43,23 @@ class ExpenseAdd extends React.Component {
     );
 
     return (
-      <Card.Body className="mt-3 p-3">
+      <Card.Body className="mt-3 py-3 px-2">
         <Form onSubmit={this.handleSubmit}>
           <InputGroup>
             <Form.Control
+              className="mr-2"              
               as="select"
               defaultValue="Add category"
               required
               id="inputCategory"
-              style={{ width: "52px" }} // FIXME
+              style={{ width: "100px" }} 
             >
               <option value="">Add category</option>
               {categoriesList}
             </Form.Control>
             <FormControl
               placeholder={expenseInputLabel}
-              className="text-center"
+              className="text-center mr-2"
               type="number"
               step=".01"
               required

--- a/frontend/src/phrases/App.json
+++ b/frontend/src/phrases/App.json
@@ -21,7 +21,7 @@
 
     "expensesLabel":"Total Expenses",
     "expensePageLinkLabel":"Add expense",
-    "expenseInputLabel":"e.g. 100 €",
+    "expenseInputLabel":"e.g. 10 €",
 
     "balanceLabel":"Balance"
 }


### PR DESCRIPTION
Expense select, input: margin added to have the elements inline w added expense items.
Placeholder text  changed to fit the number input field (phrases: App.json)

![image](https://user-images.githubusercontent.com/69510109/100424153-dbc03800-3095-11eb-9b00-e134c7bc4503.png)
